### PR TITLE
Simplify Dired Omit Mode setup

### DIFF
--- a/ignoramus.el
+++ b/ignoramus.el
@@ -910,10 +910,7 @@ character for that system."
 (defun ignoramus-do-ignore-dired ()
   "Tell `dired-mode' to ignore unwanted files."
 
-  (setq dired-omit-mode t)
-  (add-hook 'dired-mode-hook #'(lambda ()
-                                 (when (eq major-mode 'dired-mode)
-                                   (dired-omit-mode 1))))
+  (add-hook 'dired-mode-hook #'dired-omit-mode)
 
   ;; Ignoramus merges the patterns for "garbage" (dired.el) and
   ;; "omit" (dired-x.el) so they are identical.


### PR DESCRIPTION
I'm not sure whether this breaks anything, but I stumbled over this code when I was trying to find out why Dired Omit Mode was enabled even in unrelated buffers.

I'm not sure why you changed `dired-omit-mode` globally, but it has no effect anyway, since modes are never enabled by changing their variable.