### PR TITLE
Replace cl with cl-lib

### DIFF
--- a/ert-tests/ignoramus-test.el
+++ b/ert-tests/ignoramus-test.el
@@ -450,7 +450,7 @@
                          (when (and (functionp sym)
                                     (string-match "\\`ignoramus-do-ignore-\\(.+\\)" (symbol-name sym))
                                     (memq (intern (match-string 1 (symbol-name sym))) ignoramus-known-actions))
-                           (incf count)))))
+                           (cl-incf count)))))
          count))))
 
 

--- a/ignoramus.el
+++ b/ignoramus.el
@@ -8,6 +8,7 @@
 ;; Version: 0.7.4
 ;; Last-Updated: 14 Apr 2016
 ;; EmacsWiki: Ignoramus
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: convenience, tools
 ;;
 ;; Simplified BSD License
@@ -155,8 +156,8 @@
 
 ;;; requirements
 
-;; for callf
-(require 'cl)
+;; for cl-callf
+(require 'cl-lib)
 
 (autoload 'dired-omit-mode "dired-x" "Toggle omission of uninteresting files in Dired (Dired-Omit mode)." t)
 
@@ -788,7 +789,7 @@ Also identify bogons."
 
 (defun ignoramus--extract-strings (arg)
   "Return a list of strings which may be contained in or referred to in ARG."
-  (remove-if-not 'stringp
+  (cl-remove-if-not 'stringp
                  (ignoramus-list-flatten
                   (ignoramus--string-or-symbol arg))))
 
@@ -1019,7 +1020,7 @@ TYPE may be one of 'basename, 'completepath, 'prefix, or
 
 Optional UNREGISTER tells ignoramus to forget about
 SYMBOL-OR-STRING."
-  (assert (memq type '(basename completepath prefix dirprefix)) nil "bad TYPE")
+  (cl-assert (memq type '(basename completepath prefix dirprefix)) nil "bad TYPE")
   (let ((sym (intern (format "ignoramus-datafile-%s" type))))
     (if unregister
         (set sym (delete symbol-or-string (symbol-value sym)))
@@ -1058,9 +1059,9 @@ ACTIONS is optional, and defaults to the value of
 
 If ACTIONS contains 'all, turn on ignoring files for all
 actions in `ignoramus-known-actions'."
-  (callf or actions ignoramus-default-actions)
+  (cl-callf or actions ignoramus-default-actions)
   (when (symbolp actions)
-    (callf list actions))
+    (cl-callf list actions))
   (when (memq 'all actions)
     (setq actions ignoramus-known-actions))
   (setq actions (remq 'all actions))
@@ -1085,7 +1086,7 @@ actions in `ignoramus-known-actions'."
 ;; End:
 ;;
 ;; LocalWords: Ignoramus ARGS alist Howto pathname dired ignorable
-;; LocalWords: callf datafiles datafile completepath dirprefix
+;; LocalWords: cl-callf datafiles datafile completepath dirprefix
 ;;
 
 ;;; ignoramus.el ends here

--- a/ignoramus.el
+++ b/ignoramus.el
@@ -1,4 +1,4 @@
-;;; ignoramus.el --- Ignore backups, build files, et al.
+;;; ignoramus.el --- Ignore backups, build files, et al. -*- lexical-binding: t -*-
 ;;
 ;; Copyright (c) 2012-2015 Roland Walker
 ;;


### PR DESCRIPTION
Emacs 27.1 officially deprecated cl in favor of cl-lib.

I've been using this for a few months, and everything seems to work fine